### PR TITLE
Correção do title do elemento img - Teclado Braille

### DIFF
--- a/_posts/2014/2014-09-19-episodio-111-programando-no-escuro.html
+++ b/_posts/2014/2014-09-19-episodio-111-programando-no-escuro.html
@@ -6,8 +6,8 @@ episode: 1
 podcast_file_name: 'grokpodcast-111-programando-no-escuro.mp3'
 duration: '35:59'
 img_src: '/images/2014/09/teclado_braille.jpg'
-img_alt: 'RubyConf Brasil 2014'
-img_title: 'RubyConf Brasil 2014'
+img_alt: 'Teclado Braille'
+img_title: 'Teclado Braille'
 tags:
 - Podcast
 - Convidados


### PR DESCRIPTION
Olá senhores!

Percebi que na pagina de arquivo (http://www.grokpodcast.com/arquivo/) um "tooltips"/title de uma das imagens estava errado

https://imagizer.imageshack.us/v2/895x378q90/674/8iyop7.png

Aproveitar para elogiar o trabalho de vocês, keep goin' :+1: 

\o~
