### PR TITLE
fixing hover fx in home

### DIFF
--- a/stylesheets/gp-core.css
+++ b/stylesheets/gp-core.css
@@ -673,7 +673,7 @@ header a:hover {
   background: #7B7B90;
   color: #fff;
   display: block;
-  padding: 20px;
+  padding: 10px 20px;
   float: left;
   font-size: 38px;
   border-radius: 5px;


### PR DESCRIPTION
Apenas uma correção no efeito hover em posts da home,

Estava assim:

![bug-hover](https://cloud.githubusercontent.com/assets/145570/4864802/47f6f790-611f-11e4-8dea-25254c956f1c.png)

Ficou assim:

![fix-hover](https://cloud.githubusercontent.com/assets/145570/4864806/4ed411f6-611f-11e4-8a10-496fb360bf35.png)
