### PR TITLE
Link para a própria página

### DIFF
--- a/_posts/2014/2014-11-20-episodio-120-desenvolvendo-games.html
+++ b/_posts/2014/2014-11-20-episodio-120-desenvolvendo-games.html
@@ -42,7 +42,8 @@ shownotes:
   - "https://www.facebook.com/FormigaVikingAlienigena": "A Formiga Viking Alienígena"
   - "https://www.youtube.com/watch?v=EpoAGfyXxRI": "Formiga Viking Alienígena - Festival de Jogos - SBGames 2013 - YouTube"
   - "http://buy.indiegamethemovie.com/": "Indie Game: The Movie"
-  - "": "Links da sessão de cartas"
+  
+  Links da sessão de cartas
   - "http://www.facebook.com/aprendendopordiversao": "Aprendendo por diversão - mande videos contando por que é importante aprender programação para aprendendopordiversao@gmail.com"
   - "https://www.youtube.com/watch?v=RaNcCOBb3RI": "Coding Dojo: Muito além do código - YouTube"
   - "https://www.facebook.com/media/set/?set=a.1486906774929719.1073741829.1424699921150405&type=3": "FETEMAS (Feira Tecnologia Mário Spinelli)"


### PR DESCRIPTION
Ao clicar aqui a página está retornando para o mesma página e não para uma outra em especifico.
